### PR TITLE
Add Yodlee module with API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /build
 
 # misc
+.env
 .eslintcache
 .DS_Store
 .env.local

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { FroppaCard, SpendGrid } from '../../components';
+import { Yodlee } from '../../utils/Yodlee';
 import './HomePage.css';
+
+// test Yodlee API calls for account and transaction data
+Yodlee.getTokenInfo();
 
 // to convert to functional component if no state or props used
 class HomePage extends React.PureComponent<Record<string, unknown>, Record<string, unknown>> {

--- a/src/utils/Yodlee.tsx
+++ b/src/utils/Yodlee.tsx
@@ -1,0 +1,59 @@
+// Yodlee API calls
+export const Yodlee = {
+
+  getTokenInfo(): Promise<any> {   
+    const clientId: string = String(process.env.REACT_APP_CLIENT_ID);
+    const secret: string = String(process.env.REACT_APP_CLIENT_SECRET);
+    const testUser2: string = String(process.env.REACT_APP_TEST_USER2);
+    const headers = new Headers(); 
+    headers.append('Content-Type', 'application/x-www-form-urlencoded');
+    headers.append('Api-Version', '1.1');
+    headers.append('loginName', testUser2);
+
+    return fetch('https://sandbox.api.yodlee.com.au/ysl/auth/token', {
+      method: 'POST',
+      headers,
+      body: `clientId=${clientId}&secret=${secret}`,
+      redirect: 'follow' 
+    })
+    .then(response => response.json())
+    .then(data => {
+      console.log(data.token.accessToken);
+      Yodlee.getAccounts(data.token.accessToken);
+      Yodlee.getTransactions(data.token.accessToken);
+    })        
+    .catch(error => console.log('Error: ', error.statusText));
+  },
+
+  getAccounts(token: string): Promise<any> {
+    const headers = new Headers(); 
+    headers.append('Content-Type', 'application/vnd.yodlee+json');
+    headers.append('Api-Version', '1.1');
+    headers.append('Authorization', `Bearer ${token}`);
+    
+    return fetch('https://sandbox.api.yodlee.com.au:443/ysl/accounts', {
+      method: 'GET',
+      headers,
+      redirect: 'follow'
+    })
+    .then(response => response.json())
+    .then(data => console.log(data))
+    .catch(error => console.log(error));
+  },
+
+  getTransactions(token: string): Promise<any> {
+    const headers = new Headers(); 
+    headers.append('Content-Type', 'application/vnd.yodlee+json');
+    headers.append('Api-Version', '1.1');
+    headers.append('Authorization', `Bearer ${token}`);
+
+    return fetch('https://sandbox.api.yodlee.com.au:443/ysl/transactions', {
+      method: 'GET',
+      headers,
+      redirect: 'follow'
+    })
+    .then(response => response.json())
+    .then(data => console.log(data))
+    .catch(error => console.log(error));
+  }
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -3,6 +3,4 @@ EXAMPLE:
 export const [functionName] = ([paramName(if any)]: [type]): [returnType] => {
   [function e.g. return XXXX]
 }; */
-
-// delete below empty export statement once this file is populated
 export {};


### PR DESCRIPTION
I've added a separate Yodlee module with some API calls to get account balance and transactions (after using your Fastlink setup to link Test User 2's account). 

For now, the data is automatically requested via the home page (see console) but I'm planning to integrate it properly with the home and transactions pages once I've set up the transaction page.
  