### PR TITLE
Add Yodlee fastlink code

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script type='text/javascript' src='https://cdn.yodlee.com/fastlink/v3/initialize.js'></script>
     <title>React App</title>
   </head>
   <body>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -3,11 +3,44 @@ import { FroppaCard, SpendGrid } from '../../components';
 import { Yodlee } from '../../utils/Yodlee';
 import './HomePage.css';
 
-// test Yodlee API calls for account and transaction data
-Yodlee.getTokenInfo();
-
 // to convert to functional component if no state or props used
 class HomePage extends React.PureComponent<Record<string, unknown>, Record<string, unknown>> {
+  async componentDidMount(): Promise<void> {
+    // const script = document.createElement("script");
+    // script.src = "https://cdn.yodlee.com/fastlink/v3/initialize.js";
+    // script.async = true;
+    // document.body.appendChild(script);
+
+    const token = await Yodlee.getToken();
+    console.log('token', token);
+    // this.launchFastlink(token);
+    Yodlee.getAccounts(token);
+    Yodlee.getTransactions(token);
+  };
+  
+  // launchFastlink = (token: string): void => {
+  //   const window: any;
+  //   window.fastlink.open({
+  //     fastLinkURL: 'https://sandbox-node.yodlee.com.au/authenticate/anzdevexsandbox',
+  //     accessToken: `Bearer ${token}`,
+  //     params: {
+  //       userExperienceFlow : 'Aggregation'
+  //     },
+  //     onSuccess: function (data: any) {
+  //       console.log(data);
+  //     },
+  //     onError: function (data: any) {
+  //       console.log(data);
+  //     },
+  //     onExit: function (data: any) {
+  //       console.log(data);
+  //     },
+  //     onEvent: function (data: any) {
+  //       console.log(data);
+  //     }
+  //   })
+  // };
+
   render = (): JSX.Element => {
     return (
       <div className="home-page">
@@ -16,6 +49,9 @@ class HomePage extends React.PureComponent<Record<string, unknown>, Record<strin
         <h2>Spend</h2>
         <p>(last 30 days)</p>
         <SpendGrid />
+        {/* <div id="container-fastlink">
+          <input type="submit" id="btn-fastlink" value="Link an Account" onClick={Yodlee.launchFastlink()} />
+        </div> */}
       </div>
     );
   };

--- a/src/utils/Yodlee.tsx
+++ b/src/utils/Yodlee.tsx
@@ -1,7 +1,7 @@
 // Yodlee API calls
 export const Yodlee = {
 
-  getTokenInfo(): Promise<any> {   
+  getToken(): Promise<any> {   
     const clientId: string = String(process.env.REACT_APP_CLIENT_ID);
     const secret: string = String(process.env.REACT_APP_CLIENT_SECRET);
     const testUser2: string = String(process.env.REACT_APP_TEST_USER2);
@@ -18,12 +18,37 @@ export const Yodlee = {
     })
     .then(response => response.json())
     .then(data => {
-      console.log(data.token.accessToken);
-      Yodlee.getAccounts(data.token.accessToken);
-      Yodlee.getTransactions(data.token.accessToken);
+      // console.log(data.token.accessToken);
+      // Yodlee.launchFastlink(data.token.accessToken);
+      // Yodlee.getAccounts(data.token.accessToken);
+      // Yodlee.getTransactions(data.token.accessToken);
+      return data.token.accessToken;
     })        
     .catch(error => console.log('Error: ', error.statusText));
   },
+
+  // launchFastlink(token: string): void {
+  //   let window: any;
+  //   window.fastlink.open({
+  //     fastLinkURL: 'https://sandbox-node.yodlee.com.au/authenticate/anzdevexsandbox',
+  //     accessToken: `Bearer ${token}`,
+  //     params: {
+  //       userExperienceFlow : 'Aggregation'
+  //     },
+  //     onSuccess: function (data: any) {
+  //       console.log(data);
+  //     },
+  //     onError: function (data: any) {
+  //       console.log(data);
+  //     },
+  //     onExit: function (data: any) {
+  //       console.log(data);
+  //     },
+  //     onEvent: function (data: any) {
+  //       console.log(data);
+  //     }
+  //   })
+  // },
 
   getAccounts(token: string): Promise<any> {
     const headers = new Headers(); 


### PR DESCRIPTION
Key changes:

- Moved API call for accounts and transactions to the home page (on component mounting).
- Added Yodlee Fastlink code (adapted for React) to try and launch the Fastlink window, but this needs more work to function. I've commented out the code for now.